### PR TITLE
userpass brute-forcing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ You should see your brute-force in action:
 [x] Failed: henry.hammond:Eish
 ```
 
+Alternatively, you can specify a userpass file with the ```-userpass``` option. The userpass file should be colon-delimited with one pair of credentials per line:
+
+```
+$ cat userpass.txt
+john.ford:August2016
+henry.hammond:Password!2016
+cindy.baker:Password1
+
+./ruler -domain evilcorp.ninja -brute -userpass userpass.txt -v -insecure
+
+[*] Starting bruteforce
+[+] Success: john.ford:August2016
+[x] Failed: henry.hammond:Password!2016
+[+] Success: cindy.baker:Password1
+```
+
 There are a few other flags that work with ```-brute```
 These are:
 * -stop _//stop on the first valid username:password combo_

--- a/ruler.go
+++ b/ruler.go
@@ -101,6 +101,7 @@ func main() {
 	stopSuccessPtr := flag.Bool("stop", false, "Stop on successfully finding a username/password")
 	userList := flag.String("usernames", "", "Filename for a List of usernames")
 	passList := flag.String("passwords", "", "Filename for a List of passwords")
+        userpassList := flag.String("userpass", "", "Filename for a List of username:password combinations separated by a colon, one pair per line")
 	verbosePtr := flag.Bool("v", false, "Be verbose, show failures")
 	conscPtr := flag.Int("attempts", 2, "Number of attempts before delay")
 	delayPtr := flag.Int("delay", 5, "Delay between attempts")
@@ -115,8 +116,13 @@ func main() {
 
 	if *brutePtr == true {
 		fmt.Println("[*] Starting bruteforce")
-		autodiscover.BruteForce(*domainPtr, *userList, *passList, *basicPtr, *insecurePtr, *stopSuccessPtr, *verbosePtr, *conscPtr, *delayPtr)
-		return
+		if *userpassList == "" {
+			autodiscover.BruteForce(*domainPtr, *userList, *passList, *basicPtr, *insecurePtr, *stopSuccessPtr, *verbosePtr, *conscPtr, *delayPtr)
+			return
+		} else {
+			autodiscover.UserPassBruteForce(*domainPtr, *userpassList, *basicPtr, *insecurePtr, *stopSuccessPtr, *verbosePtr, *conscPtr, *delayPtr)
+			return
+		}
 	}
 
 	config.Domain = *domainPtr

--- a/ruler.go
+++ b/ruler.go
@@ -101,7 +101,7 @@ func main() {
 	stopSuccessPtr := flag.Bool("stop", false, "Stop on successfully finding a username/password")
 	userList := flag.String("usernames", "", "Filename for a List of usernames")
 	passList := flag.String("passwords", "", "Filename for a List of passwords")
-        userpassList := flag.String("userpass", "", "Filename for a List of username:password combinations separated by a colon, one pair per line")
+	userpassList := flag.String("userpass", "", "Filename for a List of username:password combinations separated by a colon, one pair per line")
 	verbosePtr := flag.Bool("v", false, "Be verbose, show failures")
 	conscPtr := flag.Int("attempts", 2, "Number of attempts before delay")
 	delayPtr := flag.Int("delay", 5, "Delay between attempts")


### PR DESCRIPTION
Added a new option: ```-userpass```

From ```ruler -h```:
```
-userpass string
    Filename for a List of username:password combinations separated by a colon, one pair per line
```

First off, thanks for the fantastic tool. I've been getting major mileage out of it the last few weeks.

I've been on a couple assessments where I had already obtained credentials by some means (dumped & cracked hashes from the domain, plundered from shares, captured via MiTM, etc.), and I wanted to test for password reuse against the Exchange domain. However, I found it semi-tedious to set up the appropriate files for an automated brute force in a userpass style. I ended up creating this ```userpass``` option and wanted to kick it back to you guys. It takes in a colon-delimited text file:
```
$ cat userpass.txt
john.ford:August2016
henry.hammond:Password!2016
cindy.baker:Password1

./ruler -domain evilcorp.ninja -brute -userpass userpass.txt -v -insecure

[*] Starting bruteforce
[+] Success: john.ford:August2016
[x] Failed: henry.hammond:Password!2016
[+] Success: cindy.baker:Password1
```
Pretty straight-forward. It ```continue```s past blank lines, empty usernames, and lines without a delimiter. I didn't include the delay/attempts for this option -- I think in a userpass scenario the onus is on the user to be aware of duplicate accounts, but please feel free to augment as you see fit.
