### PR TITLE
"Delay" help output correctly reflects behavior.

### DIFF
--- a/ruler.go
+++ b/ruler.go
@@ -1464,7 +1464,7 @@ A tool by @_staaldraad from @sensepost to abuse Exchange Services.`
 				cli.IntFlag{
 					Name:  "delay,d",
 					Value: 5,
-					Usage: "Number of seconds to delay between attempts",
+					Usage: "Number of minutes to delay between attempts",
 				},
 				cli.BoolFlag{
 					Name:  "stop,s",


### PR DESCRIPTION
The --delay $n causes ruler to postpone the next round of guesses until $n minutes have passed. The current help output incorrectly says this value is measured in seconds.