### PR TITLE
Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Ruler has multiple functions, these have their own documentation that can be fou
 
 # Attacking Exchange
 
-The library included with Ruler allows for the creation of custom message using MAPI. This along with the Exchnage documentation is a great starting point for new research. For an example of using this library in another project, see [SensePost Liniaal].
+The library included with Ruler allows for the creation of custom message using MAPI. This along with the Exchange documentation is a great starting point for new research. For an example of using this library in another project, see [SensePost Liniaal].
 
 # License
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](http://creativecommons.org/licenses/by-nc-sa/4.0/)

--- a/autodiscover/autodiscover.go
+++ b/autodiscover/autodiscover.go
@@ -344,7 +344,9 @@ func autodiscover(domain string, mapi bool) (*utils.AutodiscoverResp, string, er
 
 	//check if we got a 200 response
 	if resp.StatusCode == 200 {
-		SessionConfig.Basic = useBasic
+        if useBasic == true { // don't overwrite --basic as pointed out here: https://github.com/sensepost/ruler/issues/67
+		    SessionConfig.Basic = useBasic
+        }
 		err := autodiscoverResp.Unmarshal(body)
 		if err != nil {
 			if SessionConfig.Verbose == true {

--- a/mapi/mapi.go
+++ b/mapi/mapi.go
@@ -33,7 +33,10 @@ var AuthSession *utils.Session
 func ExtractMapiURL(resp *utils.AutodiscoverResp) string {
 	for _, v := range resp.Response.Account.Protocol {
 		if v.TypeAttr == "mapiHttp" {
-			return v.MailStore.ExternalUrl
+			if v.MailStore.ExternalUrl != "" {
+				return v.MailStore.ExternalUrl
+			}
+			return v.MailStore.InternalUrl
 		}
 	}
 	return ""
@@ -43,7 +46,10 @@ func ExtractMapiURL(resp *utils.AutodiscoverResp) string {
 func ExtractRPCURL(resp *utils.AutodiscoverResp) string {
 	for _, v := range resp.Response.Account.Protocol {
 		if v.TypeAttr == "rpcHttp" {
-			return v.MailStore.ExternalUrl
+			if v.MailStore.ExternalUrl != "" {
+				return v.MailStore.ExternalUrl
+			}
+			return v.MailStore.InternalUrl
 		}
 	}
 	return ""

--- a/ruler.go
+++ b/ruler.go
@@ -1133,7 +1133,7 @@ func main() {
 
 	app.Name = "ruler"
 	app.Usage = "A tool to abuse Exchange Services"
-	app.Version = "2.1.10"
+	app.Version = "2.2.0"
 	app.Author = "Etienne Stalmans <etienne@sensepost.com>, @_staaldraad"
 	app.Description = `         _
  _ __ _   _| | ___ _ __

--- a/ruler.go
+++ b/ruler.go
@@ -164,7 +164,7 @@ func brute(c *cli.Context) error {
 	if c.GlobalBool("o365") == true {
 		domain = "https://autodiscover-s.outlook.com/autodiscover/autodiscover.xml"
 	}
-	if e := autodiscover.Init(domain, c.String("users"), c.String("passwords"), c.String("userpass"), c.GlobalBool("basic"), c.GlobalBool("insecure"), c.Bool("stop"), c.Bool("verbose"), c.Int("attempts"), c.Int("delay"), c.Int("threads")); e != nil {
+	if e := autodiscover.Init(domain, c.String("users"), c.String("passwords"), c.String("userpass"),c.String("proxy"), c.GlobalBool("basic"), c.GlobalBool("insecure"), c.Bool("stop"), c.Bool("verbose"), c.Int("attempts"), c.Int("delay"), c.Int("threads")); e != nil {
 		return e
 	}
 


### PR DESCRIPTION
Some enhancements suggested through the issue tracker.

* adds --proxy support for brute forcing
* displays progress during brute force
* uses username as password during brute force (once all possible username/password combinations have been tried. Does not apply to `--userpass`)
* Tries to use InternalURL if there is no ExternalURL available in the autodiscover.xml