### PR TITLE
fix HTTP WWW-Authenticate header parsing

### DIFF
--- a/http-ntlm/ntlmtransport.go
+++ b/http-ntlm/ntlmtransport.go
@@ -93,9 +93,13 @@ func (t NtlmTransport) RoundTrip(req *http.Request) (res *http.Response, err err
 			return nil, err
 		}
 
-		// retrieve Www-Authenticate header from response
-
-		ntlmChallengeHeader := resp.Header.Get("WWW-Authenticate")
+		// retrieve WWW-Authenticate header from response
+		ntlmChallengeHeader := ""
+		for _, header := range resp.Header[http.CanonicalHeaderKey("WWW-Authenticate")] {
+			if strings.HasPrefix(header, "NTLM") {
+				ntlmChallengeHeader = header
+			}
+		}
 		if ntlmChallengeHeader == "" {
 			return nil, errors.New("Wrong WWW-Authenticate header")
 		}

--- a/rpc-http/rpctransport.go
+++ b/rpc-http/rpctransport.go
@@ -101,9 +101,12 @@ func setupHTTP(rpctype string, URL string, ntlmAuth bool, full bool) (net.Conn, 
 		ntlmChallengeHeader := ""
 		for _, v := range parts {
 			if n := strings.Split(v, ": "); len(n) > 0 {
-				if n[0] == "WWW-Authenticate" {
-					ntlmChallengeHeader = n[1]
-					break
+				//sometimes header name may be WWW or Www
+				if strings.ToLower(n[0]) == strings.ToLower("WWW-Authenticate") {
+					if strings.HasPrefix(n[1], "NTLM") {
+						ntlmChallengeHeader = n[1]
+						break
+					}
 				}
 			}
 		}


### PR DESCRIPTION
There was an issue with parsing WWW-Authenticate header while it starts with `Www` rather than `WWW`
NTLM parsing has also been fixed (`resp.Header.Get` returns the first found value, but it doesn't mean it will an NTLM value)