### PR TITLE
Fix authentication bug

### DIFF
--- a/autodiscover/autodiscover.go
+++ b/autodiscover/autodiscover.go
@@ -300,11 +300,9 @@ func autodiscover(domain string, mapi bool) (*utils.AutodiscoverResp, string, er
 
 	var autodiscoverURL string
 	//check if this is just a domain, a redirect or a url (starts with http[s]://)
-
 	if m, _ := regexp.Match("http[s]?://", []byte(domain)); m == true {
 		autodiscoverURL = domain
 	} else {
-
 		//create the autodiscover url
 		if autodiscoverStep == 0 {
 			autodiscoverURL = createAutodiscover(fmt.Sprintf("autodiscover.%s", domain), true)
@@ -336,13 +334,14 @@ func autodiscover(domain string, mapi bool) (*utils.AutodiscoverResp, string, er
 		req.Header.Add("X-AnchorMailbox", SessionConfig.Email) //we want MAPI info
 	}
 
-	//if we have been redirected to outlook, change the auth header to basic auth
-	if SessionConfig.Basic == false {
-		req.SetBasicAuth(SessionConfig.Email, SessionConfig.Pass)
-		SessionConfig.BasicAuth = req.Header.Get("WWW-Authenticate")
-	} else {
-		req.SetBasicAuth(SessionConfig.User, SessionConfig.Pass)
+	if SessionConfig.Basic == true {
+		if SessionConfig.Domain != "" {
+			req.SetBasicAuth(SessionConfig.Domain + "\\" + SessionConfig.User, SessionConfig.Pass)
+		} else {
+			req.SetBasicAuth(SessionConfig.Email, SessionConfig.Pass)
+		}
 	}
+
 	//request the autodiscover url
 	resp, err := client.Do(req)
 

--- a/mapi/mapi.go
+++ b/mapi/mapi.go
@@ -173,18 +173,23 @@ func sendMapiDisconnect(mapi DisconnectRequest) ([]byte, error) {
 //After the authentication is complete, we can simply use the mapiRequest
 //and the session cookies.
 func mapiRequestHTTP(URL, mapiType string, body []byte) ([]byte, error) {
-
 	req, err := http.NewRequest("POST", URL, bytes.NewReader(body))
 	addMapiHeaders(req, mapiType)
 	req.Header.Add("User-Agent", AuthSession.UserAgent)
-	req.SetBasicAuth(AuthSession.Email, AuthSession.Pass)
-
+	if AuthSession.Basic == true {
+		if AuthSession.Domain != "" {
+			req.SetBasicAuth(AuthSession.Domain + "\\" + AuthSession.User, AuthSession.Pass)
+		} else {
+			req.SetBasicAuth(AuthSession.Email, AuthSession.Pass)
+		}
+	}
 	req.Close = true
+
 	//request the auth url
 	resp, err := client.Do(req)
 
 	if err != nil {
-		//check if this error was because of ntml auth when basic auth was expected.
+		//check if this error was because of ntlm auth when basic auth was expected.
 		if m, _ := regexp.Match("illegal base64", []byte(err.Error())); m == true {
 			resp, err = client.Do(req)
 		} else {

--- a/utils/datatypes.go
+++ b/utils/datatypes.go
@@ -49,7 +49,6 @@ type Session struct {
 	RulesHandle   []byte
 	NTHash        []byte
 	NTLMAuth      string
-	BasicAuth     string
 
 	RPCSet              bool
 	ContextHandle       []byte //16-byte cookie for the RPC session


### PR DESCRIPTION
The first part corrects my PR #107 a bit (forgot to check the --basic option)
The second one fixes Basic authentication. Now it passes the value of --domain option (if specified) as the domain value, but not the domain value of the email address