### PR TITLE
add --hostname option

### DIFF
--- a/autodiscover/autodiscover.go
+++ b/autodiscover/autodiscover.go
@@ -280,6 +280,7 @@ func autodiscover(domain string, mapi bool) (*utils.AutodiscoverResp, string, er
 				Insecure:  SessionConfig.Insecure,
 				CookieJar: SessionConfig.CookieJar,
 				Proxy:     SessionConfig.Proxy,
+				Hostname:  SessionConfig.Hostname,
 			},
 			Jar: SessionConfig.CookieJar,
 		}

--- a/autodiscover/brute.go
+++ b/autodiscover/brute.go
@@ -25,7 +25,6 @@ type Result struct {
 }
 
 var concurrency = 3 //limit the number of consecutive attempts
-
 var delay = 5
 var consc = 3
 var usernames []string
@@ -38,6 +37,7 @@ var insecure = false
 var stopSuccess = false
 var proxyURL string
 var userAgent string
+var hostname string
 var user_as_pass = true
 
 func autodiscoverDomain(domain string) string {
@@ -115,7 +115,7 @@ func autodiscoverDomain(domain string) string {
 }
 
 //Init function to setup the brute-force session
-func Init(domain, usersFile, passwordsFile, userpassFile, pURL, u string, b, i, s, v bool, c, d, t int) error {
+func Init(domain, usersFile, passwordsFile, userpassFile, pURL, u, n string, b, i, s, v bool, c, d, t int) error {
 	stopSuccess = s
 	insecure = i
 	basic = b
@@ -125,6 +125,7 @@ func Init(domain, usersFile, passwordsFile, userpassFile, pURL, u string, b, i, 
 	concurrency = t
 	proxyURL = pURL
 	userAgent = u
+	hostname = n
 
 	autodiscoverURL = autodiscoverDomain(domain)
 
@@ -354,6 +355,7 @@ func connect(autodiscoverURL, user, password string, basic, insecure bool) Resul
 				Password:  password,
 				Insecure:  insecure,
 				CookieJar: cookie,
+				Hostname:  hostname,
 			},
 		}
 	}

--- a/http-ntlm/ntlmtransport.go
+++ b/http-ntlm/ntlmtransport.go
@@ -32,6 +32,7 @@ type NtlmTransport struct {
 	NTHash    []byte
 	Insecure  bool
 	CookieJar *cookiejar.Jar
+	Hostname  string
 }
 
 var Transport http.Transport
@@ -75,7 +76,6 @@ func (t NtlmTransport) RoundTrip(req *http.Request) (res *http.Response, err err
 	client := http.Client{Transport: tr, Timeout: time.Minute, Jar: t.CookieJar}
 
 	resp, err := client.Do(r)
-
 	if err != nil {
 		return nil, err
 	}
@@ -121,6 +121,10 @@ func (t NtlmTransport) RoundTrip(req *http.Request) (res *http.Response, err err
 		// authenticate user
 		authenticate, err := session.GenerateAuthenticateMessage()
 		//fmt.Printf("%x\n", authenticate.Bytes())
+		if err != nil {
+			return nil, err
+		}
+		authenticate.Workstation, err = ntlm.CreateStringPayload(t.Hostname)
 		if err != nil {
 			return nil, err
 		}

--- a/mapi/mapi.go
+++ b/mapi/mapi.go
@@ -89,6 +89,7 @@ func Init(config *utils.Session, lid, URL, ABKURL string, transport int) {
 					Insecure:  AuthSession.Insecure,
 					CookieJar: AuthSession.CookieJar,
 					Proxy:     AuthSession.Proxy,
+					Hostname:  AuthSession.Hostname,
 				},
 				Jar: AuthSession.CookieJar,
 			}

--- a/ruler.go
+++ b/ruler.go
@@ -93,8 +93,17 @@ func discover(c *cli.Context) error {
 	config.CookieJar, _ = cookiejar.New(nil)
 	config.Proxy = c.GlobalString("proxy")
 	config.UserAgent = c.GlobalString("useragent")
-	url := c.GlobalString("url")
 
+	config.Hostname = c.GlobalString("hostname")
+	if config.Hostname == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			return fmt.Errorf("An error is occurred while getting Hostname value. Try to specify it manually using --hostname")
+		}
+		config.Hostname = hostname
+	}
+
+	url := c.GlobalString("url")
 	if url == "" {
 		url = config.Domain
 	}
@@ -165,7 +174,7 @@ func brute(c *cli.Context) error {
 	if c.GlobalBool("o365") == true {
 		domain = "https://autodiscover-s.outlook.com/autodiscover/autodiscover.xml"
 	}
-	if e := autodiscover.Init(domain, c.String("users"), c.String("passwords"), c.String("userpass"), c.GlobalString("proxy"), c.GlobalString("useragent"), c.GlobalBool("basic"), c.GlobalBool("insecure"), c.Bool("stop"), c.Bool("verbose"), c.Int("attempts"), c.Int("delay"), c.Int("threads")); e != nil {
+	if e := autodiscover.Init(domain, c.String("users"), c.String("passwords"), c.String("userpass"), c.GlobalString("proxy"), c.GlobalString("useragent"), c.GlobalString("hostname"), c.GlobalBool("basic"), c.GlobalBool("insecure"), c.Bool("stop"), c.Bool("verbose"), c.Int("attempts"), c.Int("delay"), c.Int("threads")); e != nil {
 		return e
 	}
 
@@ -315,6 +324,16 @@ func connect(c *cli.Context) error {
 	config.CookieJar, _ = cookiejar.New(nil)
 	config.Proxy = c.GlobalString("proxy")
 	config.UserAgent = c.GlobalString("useragent")
+
+	config.Hostname = c.GlobalString("hostname")
+	if config.Hostname == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			return fmt.Errorf("An error is occurred while getting Hostname value. Try to specify it manually using --hostname")
+		}
+		config.Hostname = hostname
+	}
+
 	//add supplied cookie to the cookie jar
 	if c.GlobalString("cookie") != "" {
 		//split into cookies and then into name : value
@@ -343,33 +362,6 @@ func connect(c *cli.Context) error {
 	}
 
 	config.CookieJar, _ = cookiejar.New(nil)
-
-	//add supplied cookie to the cookie jar
-	if c.GlobalString("cookie") != "" {
-		//split into cookies and then into name : value
-		cookies := strings.Split(c.GlobalString("cookie"), ";")
-		var cookieJarTmp []*http.Cookie
-		var cdomain string
-		//split and get the domain from the email
-		if eparts := strings.Split(c.GlobalString("email"), "@"); len(eparts) == 2 {
-			cdomain = eparts[1]
-		} else {
-			return fmt.Errorf("Invalid email address")
-		}
-
-		for _, v := range cookies {
-			cookie := strings.Split(v, "=")
-			c := &http.Cookie{
-				Name:   cookie[0],
-				Value:  cookie[1],
-				Path:   "/",
-				Domain: cdomain,
-			}
-			cookieJarTmp = append(cookieJarTmp, c)
-		}
-		u, _ := url.Parse(fmt.Sprintf("https://%s/", cdomain))
-		config.CookieJar.SetCookies(u, cookieJarTmp)
-	}
 
 	url := c.GlobalString("url")
 
@@ -1219,6 +1211,11 @@ A tool by @_staaldraad from @sensepost to abuse Exchange Services.`
 		cli.BoolFlag{
 			Name:  "rpc",
 			Usage: "Force RPC/HTTP rather than MAPI/HTTP",
+		},
+		cli.StringFlag{
+			Name:  "hostname,n",
+			Value: "RULER",
+			Usage: "Custom Hostname value",
 		},
 		cli.BoolFlag{
 			Name:  "verbose",

--- a/utils/datatypes.go
+++ b/utils/datatypes.go
@@ -19,6 +19,7 @@ type Config struct {
 	Admin     bool
 	Proxy     string
 	UserAgent string
+	Hostname string
 }
 
 //Session stores authentication cookies etc
@@ -47,6 +48,7 @@ type Session struct {
 	Authenticated bool
 	Folderids     [][]byte
 	RulesHandle   []byte
+	Hostname      string
 	NTHash        []byte
 	NTLMAuth      string
 	BasicAuth     string


### PR DESCRIPTION
@mohemiv noticed that ruler uses predefined value "RULER" while using NTLM authentication
so i have added the --hostname option to specify any value as a host name